### PR TITLE
Lean 4 web へのリンクを追加する

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -15,7 +15,7 @@ Lean は証明支援系でもあり，数学の証明を検証する能力を備
 
 現在，Lean で数学理論を実装していこうという努力が積極的に行われています．[mathlib4](https://github.com/leanprover-community/mathlib4) というライブラリがあり，大学の学部程度の数学のかなりの部分を Lean で行うことが可能になっています．
 
-あなたも Lean で新しい数学を体験してみませんか？
+[Lean 4 Web](https://lean.math.hhu.de/) から Lean を試すことができます．あなたも Lean で新しい数学を体験してみませんか？
 
 ## __わたしたちについて__
 


### PR DESCRIPTION
https://github.com/lean-ja/lean-ja.github.io/pull/13#discussion_r1325921563

でおっしゃっていたことを再度検討してみました．zola の機能として長いURLをどこかに定数として格納する機能があればそれを利用したのですが，探した限り見つからなかったので，空のURLを貼っています．

lean 4 web にはExampleを見る機能もあるので，これでもいいかなと思いましたが，いかがでしょうか？